### PR TITLE
Use `sensitive true` for each template using the private key

### DIFF
--- a/recipes/combined_chain_pem_file.rb
+++ b/recipes/combined_chain_pem_file.rb
@@ -36,6 +36,7 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
       owner 'root'
       group node['ssl-vault']['cert_group']
       mode '0440'
+      sensitive true
       variables(
         :certificate => vault_item['certificate'],
         :chain_certificates => vault_item['chain_certificates'],

--- a/recipes/pem_file.rb
+++ b/recipes/pem_file.rb
@@ -34,6 +34,7 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
     owner 'root'
     group node['ssl-vault']['cert_group']
     mode '0440'
+    sensitive true
     variables(
       :key => vault_item['key'],
       :certificate => vault_item['certificate']

--- a/recipes/private_key_file.rb
+++ b/recipes/private_key_file.rb
@@ -34,6 +34,7 @@ node['ssl-vault']['certificates'].each do |cert_name, cert|
     owner 'root'
     group node['ssl-vault']['cert_group']
     mode '0440'
+    sensitive true
   end
 
   node.set['ssl-vault']['certificate'][cert_name]['private_key_file'] = private_key


### PR DESCRIPTION
Hi,

As requested in #13, this add the `sensitive true` flag for each template with the private key.
With this, the output & logs don't print the key anymore.

Thanks for reviewing.